### PR TITLE
Add Slack notifications after downtime

### DIFF
--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -17,18 +17,10 @@ jobs:
           for ISSUE in $ISSUES; do
             echo "Checking issue #$ISSUE..."
 
-            COMMENT=$(gh issue view $ISSUE --json comments --jq \
-              '.comments[] | select(.body | test("<!--slack-reminder-start-->")) | .body')
-
-            if [ -z "$COMMENT" ]; then
-              echo "No marker comment found. Skipping."
-              continue
-            fi
-
-            START=$(echo "$COMMENT" | grep "Reminder started at:" | cut -d: -f2- | xargs)
-            START_EPOCH=$(date -d "$START" +%s)
+            CREATED_AT=$(gh issue view $ISSUE --json createdAt --jq '.createdAt')
+            CREATED_EPOCH=$(date -d "$CREATED_AT" +%s)
             NOW_EPOCH=$(date -u +%s)
-            DIFF=$((NOW_EPOCH - START_EPOCH))
+            DIFF=$((NOW_EPOCH - CREATED_EPOCH))
 
             # TODO: Value lowered to 0 for testing
             # if [ "$DIFF" -ge 86400 ]; then
@@ -40,7 +32,7 @@ jobs:
                 ${{ secrets.SLACK_WEBHOOK_URL }}
 
               echo "Marking reminder complete for issue #$ISSUE"
-              gh issue comment $ISSUE --body "<!--slack-reminder-complete--> Follow-up sent at $(date -u)"
+              gh issue comment $ISSUE --body "Slack reminder sent at $(date -u)"
               gh issue remove-label $ISSUE slack-reminder
             else
               echo "Not yet 24h. Skipping."

--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -1,0 +1,50 @@
+name: Send Slack Message from Issue
+
+on:
+  schedule:
+    - cron: "*/15 * * * *" # Every 15 minutes
+  workflow_dispatch:
+
+jobs:
+  repeat:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required to comment and read issues
+    steps:
+      - name: Repeat reminders if 24h elapsed
+        run: |
+          ISSUES=$(gh issue list --label "slack-reminder" --state open --json number --jq '.[].number')
+          for ISSUE in $ISSUES; do
+            echo "Checking issue #$ISSUE..."
+
+            COMMENT=$(gh issue view $ISSUE --json comments --jq \
+              '.comments[] | select(.body | test("<!--slack-reminder-start-->")) | .body')
+
+            if [ -z "$COMMENT" ]; then
+              echo "No marker comment found. Skipping."
+              continue
+            fi
+
+            START=$(echo "$COMMENT" | grep "Reminder started at:" | cut -d: -f2- | xargs)
+            START_EPOCH=$(date -d "$START" +%s)
+            NOW_EPOCH=$(date -u +%s)
+            DIFF=$((NOW_EPOCH - START_EPOCH))
+
+            # TODO: Value lowered to 0 for testing
+            # if [ "$DIFF" -ge 86400 ]; then
+            if [ "$DIFF" -ge 0 ]; then
+              echo "Sending notification for issue #$ISSUE"
+
+              curl -X POST -H 'Content-type: application/json' \
+                --data "{\"text\":\"24 hour follow-up from downtime event #$ISSUE (https://github.com/IronCoreLabs/upptime/issues/$ISSUE). Please take action.\"}" \
+                ${{ secrets.SLACK_WEBHOOK_URL }}
+
+              echo "Marking reminder complete for issue #$ISSUE"
+              gh issue comment $ISSUE --body "<!--slack-reminder-complete--> Follow-up sent at $(date -u)"
+              gh issue remove-label $ISSUE slack-reminder
+            else
+              echo "Not yet 24h. Skipping."
+            fi
+          done
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/issue-open.yml
+++ b/.github/workflows/issue-open.yml
@@ -15,10 +15,3 @@ jobs:
         with:
           github_token: ${{ secrets.WORKFLOW_PAT }}
           labels: slack-reminder
-      - name: Add marker comment
-        run: |
-          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          BODY="<!--slack-reminder-start-->\nReminder started at: $TIMESTAMP"
-          gh issue comment ${{ github.event.issue.number }} --body "$BODY"
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/issue-open.yml
+++ b/.github/workflows/issue-open.yml
@@ -1,0 +1,24 @@
+name: Slack Reminder on Issue Open
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  post_reminder:
+    # TODO: Un-comment after testing
+    # if: github.event.issue.user.name == 'leeroy-travis'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add tracking label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.WORKFLOW_PAT }}
+          labels: slack-reminder
+      - name: Add marker comment
+        run: |
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          BODY="<!--slack-reminder-start-->\nReminder started at: $TIMESTAMP"
+          gh issue comment ${{ github.event.issue.number }} --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.WORKFLOW_PAT }}


### PR DESCRIPTION
`issue-open.yml` triggers when an issue is opened and puts a label on the issue.
`issue-notify.yml` runs on an every-15-minute cron and checks to see if any issues with the label are more than 24 hours old, sends a Slack message, and removes the label.

I doubt this will work perfectly first try. But it's a start to iterate on